### PR TITLE
Adicionar testes unitários para ArrayExtensions

### DIFF
--- a/DevToolz.Library.Test/Extensions/ArrayExtensionsTests.cs
+++ b/DevToolz.Library.Test/Extensions/ArrayExtensionsTests.cs
@@ -1,0 +1,96 @@
+namespace DevToolz.Library.Test.Extensions;
+
+public class ArrayExtensionsTests
+{
+    [Fact]
+    public void ForEach_WithIntArray_ExecutesActionForEachElement()
+    {
+        // Arrange
+        Array numbers = new int[] { 1, 2, 3 };
+        var result = new List<int>();
+
+        // Act
+        numbers.ForEach<int>( value => result.Add( value ) );
+
+        // Assert
+        Assert.Equal( new List<int> { 1, 2, 3 }, result );
+    }
+
+    [Fact]
+    public void ToList_WithStringArray_ReturnsTypedList()
+    {
+        // Arrange
+        Array values = new string[] { "A", "B", "C" };
+
+        // Act
+        var result = values.ToList<string>();
+
+        // Assert
+        Assert.Equal( new List<string> { "A", "B", "C" }, result );
+    }
+
+    [Fact]
+    public void ToCharSeparatedList_WithPipeSeparator_ReturnsConcatenatedString()
+    {
+        // Arrange
+        Array values = new int[] { 10, 20, 30 };
+
+        // Act
+        var result = values.ToCharSeparatedList( '|' );
+
+        // Assert
+        Assert.Equal( "10|20|30", result );
+    }
+
+    [Fact]
+    public void ToCommaSeparatedList_WithStringArray_ReturnsCommaSeparatedString()
+    {
+        // Arrange
+        Array values = new string[] { "one", "two", "three" };
+
+        // Act
+        var result = values.ToCommaSeparatedList();
+
+        // Assert
+        Assert.Equal( "one,two,three", result );
+    }
+
+    [Fact]
+    public void Contains_WithPredicateMatchingElement_ReturnsTrue()
+    {
+        // Arrange
+        Array values = new int[] { 1, 5, 9 };
+
+        // Act
+        var result = values.Contains<int>( i => i > 7 );
+
+        // Assert
+        Assert.True( result );
+    }
+
+    [Fact]
+    public void Contains_WithPredicateNotMatchingAnyElement_ReturnsFalse()
+    {
+        // Arrange
+        Array values = new int[] { 2, 4, 6 };
+
+        // Act
+        var result = values.Contains<int>( i => i.IsOdd() );
+
+        // Assert
+        Assert.False( result );
+    }
+
+    [Fact]
+    public void ToCharSeparatedList_WithEmptyArray_ReturnsEmptyString()
+    {
+        // Arrange
+        Array values = Array.Empty<int>();
+
+        // Act
+        var result = values.ToCharSeparatedList( ',' );
+
+        // Assert
+        Assert.Equal( string.Empty, result );
+    }
+}


### PR DESCRIPTION
### Motivation

- Melhorar a cobertura de testes para os utilitários de arrays fornecidos em `ArrayExtensions`. 
- Garantir comportamento correto em cenários comuns e de borda para as operações de iteração, conversão e busca.

### Description

- Adicionada a suíte de testes `ArrayExtensionsTests` em `DevToolz.Library.Test/Extensions/ArrayExtensionsTests.cs` contendo casos de unidade com xUnit (`[Fact]`).
- Cobertura dos métodos públicos `ForEach<T>`, `ToList<T>`, `ToCharSeparatedList`, `ToCommaSeparatedList` e `Contains<T>` com cenários positivos e negativos.
- Incluído teste de borda para `ToCharSeparatedList` usando um array vazio e casos para `Contains<T>` que retornam `true` e `false`.

### Testing

- Foi tentada a execução dos testes com `dotnet test DevToolz.Library.sln`, mas o comando falhou porque o runtime/CLI do .NET não está disponível neste ambiente (`dotnet: command not found`).
- Nenhum teste automatizado foi executado com sucesso localmente devido à indisponibilidade do `dotnet` nessa sessão.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ce9e7dd488333bdc0454bc5985903)