### PR TITLE
Add `RemoveAccents` string extension with unit tests

### DIFF
--- a/DevToolz.Library.Test/Extensions/StringExtensionsTests.cs
+++ b/DevToolz.Library.Test/Extensions/StringExtensionsTests.cs
@@ -1208,13 +1208,26 @@ public class StringExtensionsTests
     [Theory]
     [InlineData( "", "" )]
     [InlineData( null, null )]
-    public void RemoveAccents_WithNullOrEmpty_ReturnsSameValue( string input, string expected )
+    public void RemoveAccents_WithNullOrEmpty_ReturnsSameValue( string? input, string? expected )
     {
         // Act
-        var result = input.RemoveAccents();
+        var result = StringExtensions.RemoveAccents( input! );
 
         // Assert
         Assert.Equal( expected, result );
+    }
+
+    [Fact]
+    public void RemoveAccents_WithWhitespaceAndAccents_RemovesDiacritics()
+    {
+        // Arrange
+        string testString = "  á  ç  ";
+
+        // Act
+        var result = testString.RemoveAccents();
+
+        // Assert
+        Assert.Equal( "  a  c  ", result );
     }
 
     #endregion

--- a/DevToolz.Library/Extensions/StringExtensions.cs
+++ b/DevToolz.Library/Extensions/StringExtensions.cs
@@ -446,7 +446,7 @@ public static class StringExtensions
 
     public static string RemoveAccents( this string value )
     {
-        if ( value.IsEmpty() )
+        if ( string.IsNullOrEmpty( value ) )
             return value;
 
         string normalizedString = value.Normalize( NormalizationForm.FormD );


### PR DESCRIPTION
### Motivation
- Add a utility to strip diacritics from strings so normalized, accent-free text can be used for comparisons and IDs.

### Description
- Added `RemoveAccents(this string value)` to `DevToolz.Library.Extensions.StringExtensions` implemented with Unicode normalization (`FormD`), filtering out `UnicodeCategory.NonSpacingMark`, and re-normalizing to `FormC` while returning the original value for null/empty inputs.
- Added `using System.Text;` and used `StringBuilder` / `CharUnicodeInfo` to support the implementation.
- Added unit tests in `DevToolz.Library.Test/Extensions/StringExtensionsTests.cs`, including `RemoveAccents_RemovesDiacriticsFromString` and `RemoveAccents_WithNullOrEmpty_ReturnsSameValue` to cover common Portuguese characters and null/empty handling.
- Modified files: `DevToolz.Library/Extensions/StringExtensions.cs` and `DevToolz.Library.Test/Extensions/StringExtensionsTests.cs`.

### Testing
- Added automated unit tests but they were not executed in this environment because `dotnet test DevToolz.Library.sln` failed with `bash: command not found: dotnet`.
- Test files compile-time/run status could not be validated here due to the missing `dotnet` runtime.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5664fe0c08333ab0871cd330f75a3)