### PR TITLE
Fix CPF validation for repeated-digit patterns and improve generator

### DIFF
--- a/DevToolz.Library.Test/CpfTest.cs
+++ b/DevToolz.Library.Test/CpfTest.cs
@@ -19,6 +19,21 @@ public class CpfTest
         Assert.True( validator.IsValid( generator.Generate( true ) ) );
     }
 
+
+    [Theory]
+    [InlineData( "00000000000" )]
+    [InlineData( "11111111111" )]
+    [InlineData( "99999999999" )]
+    [InlineData( "000.000.000-00" )]
+    [InlineData( "111.111.111-11" )]
+    [InlineData( "999.999.999-99" )]
+    public void Validate_ShouldReturnFalse_ForRepeatedDigitsPatterns( string cpf )
+    {
+        IValidator validator = new Cpf();
+
+        Assert.False( validator.IsValid( cpf ) );
+    }
+
     [Fact]
     public void GenerateTest()
     {

--- a/DevToolz.Library/Cpf.cs
+++ b/DevToolz.Library/Cpf.cs
@@ -6,22 +6,11 @@ public class Cpf : INumber, IGenerator, IValidator
     public string Number { get => _cpf; set => _cpf = value; }
 
     private bool IsPattern( string value )
-    {
-        return value.IsEqual( "000000000" )
-            || value.IsEqual( "111111111" )
-            || value.IsEqual( "222222222" )
-            || value.IsEqual( "333333333" )
-            || value.IsEqual( "444444444" )
-            || value.IsEqual( "555555555" )
-            || value.IsEqual( "666666666" )
-            || value.IsEqual( "777777777" )
-            || value.IsEqual( "888888888" )
-            || value.IsEqual( "999999999" );
-    }
+        => value.IsNotEmpty() && value.Distinct().Count() == 1;
 
     private string GenerateCalculatingDigits()
     {
-        var rrandomDigits = new Random( DateTime.Now.Second );
+        var randomDigits = Random.Shared;
         string digits;
 
         do
@@ -29,7 +18,7 @@ public class Cpf : INumber, IGenerator, IValidator
             digits = string.Empty;
 
             for ( int i = 0; i < 9; i++ )
-                digits += rrandomDigits.Next( 0, 9 ).ToString();
+                digits += randomDigits.Next( 0, 10 ).ToString();
 
         } while ( IsPattern( digits ) );
 
@@ -77,13 +66,16 @@ public class Cpf : INumber, IGenerator, IValidator
     public bool IsValid( string value )
     {
         var validFormat = value.IsNotEmpty()
-            && IsCpfFormatValid( value )
-            && !IsPattern( value );
+            && IsCpfFormatValid( value );
 
         if ( !validFormat )
             return false;
 
         var cpf = RemoveMask( value );
+
+        if ( cpf.Length != 11 || IsPattern( cpf ) )
+            return false;
+
         var calculatingDigits = GetCalculatingDigits( cpf );
         var firstVerifyingDigit = GetFirstVerifyingDigit( cpf );
         var secondVerifyingDigit = GetSecondVerifyingDigit( cpf );


### PR DESCRIPTION
### Motivation

- Prevent CPFs composed of the same digit (including masked forms like `000.000.000-00`) from being treated as valid.  
- Remove brittle hardcoded pattern checks and replace them with a generic repeated-digit detection.  
- Make CPF generation less biased and use the modern shared RNG to improve randomness.  
- Ensure validation checks operate on the unmasked numeric value for correctness.

### Description

- Replaced many explicit repeated-values checks with `IsPattern` implemented as `value.IsNotEmpty() && value.Distinct().Count() == 1`.  
- Replaced `new Random(DateTime.Now.Second)` with `Random.Shared` and changed `Next(0, 9)` to `Next(0, 10)` in `GenerateCalculatingDigits` to include the full 0–9 range.  
- Deferred repeated-digit detection until after calling `RemoveMask` and added an explicit length guard `if (cpf.Length != 11 || IsPattern(cpf)) return false;` inside `IsValid`.  
- Added a unit test `Validate_ShouldReturnFalse_ForRepeatedDigitsPatterns` that asserts masked and unmasked repeated-digit CPFs are rejected.

### Testing

- Attempted to run the test suite with `dotnet test --nologo`, but the command failed because the environment lacks the .NET SDK (`dotnet: command not found`).  
- No automated tests were executed successfully in this environment due to the missing `dotnet` runtime.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a582e080e88333a28c7af1e6ff4441)