### PR TITLE
Add concurrency control to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,10 @@ on:
   pull_request:
     branches-ignore: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   Testar:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Added concurrency configuration to the GitHub Actions build workflow to prevent multiple workflow runs from executing simultaneously and to cancel in-progress runs when new commits are pushed.

## Key Changes
- Added `concurrency` block to the build workflow configuration
- Configured concurrency group using workflow name and git reference (head ref for PRs, ref name for other branches)
- Enabled `cancel-in-progress` to automatically cancel previous runs when a new workflow is triggered

## Implementation Details
This change improves CI/CD efficiency by:
- Preventing resource contention when multiple workflow runs would execute in parallel
- Automatically canceling outdated workflow runs when new commits are pushed to the same branch or pull request
- Using `github.head_ref || github.ref_name` to properly handle both pull request and push events

https://claude.ai/code/session_01MycJoWgTZDW6nNxkYSfZmv